### PR TITLE
Display USACE Brookville 24-hour change metrics

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4,6 +4,18 @@ from datetime import datetime
 from streamlit_autorefresh import st_autorefresh
 from scraper import fetch_usace_brookville_data
 
+
+def format_delta(delta, unit):
+    """Return HTML snippet showing 24 hour change with color coding."""
+    if delta is None:
+        text = "24 hour change: N/A"
+        color = "gray"
+    else:
+        color = "green" if delta > 0 else "red" if delta < 0 else "gray"
+        sign = "+" if delta > 0 else ""
+        text = f"24 hour change: {sign}{delta:.2f} {unit}"
+    return f'<span style="font-size:0.5em;color:{color}">{text}</span>'
+
 # --- REMOVE TOP PADDING VIA CSS ---
 st.markdown(
     """
@@ -50,8 +62,20 @@ if usace:
         st.metric("Elevation", usace["elevation"] or "N/A")
         c1, c2 = st.columns(2)
         c1.metric("Inflow", usace["inflow"] or "N/A")
+        c1.markdown(
+            format_delta(usace.get("inflow_delta"), usace.get("inflow_unit")),
+            unsafe_allow_html=True,
+        )
         c2.metric("Outflow", usace["outflow"] or "N/A")
+        c2.markdown(
+            format_delta(usace.get("outflow_delta"), usace.get("outflow_unit")),
+            unsafe_allow_html=True,
+        )
         st.metric("Storage", usace["storage"] or "N/A")
+        st.markdown(
+            format_delta(usace.get("storage_delta"), usace.get("storage_unit")),
+            unsafe_allow_html=True,
+        )
         st.metric("Precipitation", usace["precipitation"] or "N/A")
 else:
     st.error("⚠️ Could not load Brookville Reservoir data.")

--- a/scraper.py
+++ b/scraper.py
@@ -54,8 +54,14 @@ def fetch_usace_brookville_data():
         result = {
             "elevation": None,
             "inflow": None,
+            "inflow_delta": None,
+            "inflow_unit": None,
             "outflow": None,
+            "outflow_delta": None,
+            "outflow_unit": None,
             "storage": None,
+            "storage_delta": None,
+            "storage_unit": None,
             "precipitation": None,
         }
 
@@ -63,18 +69,25 @@ def fetch_usace_brookville_data():
             label = ts.get("label", "").lower()
             value = ts.get("latest_value")
             unit = ts.get("unit", "")
+            delta = ts.get("delta24hr")
             formatted = f"{value} {unit}" if value is not None else None
 
             if label == "elevation":
                 result["elevation"] = formatted
             elif label == "inflow":
                 result["inflow"] = formatted
+                result["inflow_delta"] = delta
+                result["inflow_unit"] = unit
             elif label == "outflow":
                 result["outflow"] = formatted
+                result["outflow_delta"] = delta
+                result["outflow_unit"] = unit
             elif label == "precipitation":
                 result["precipitation"] = formatted
             elif "storage" in label and result["storage"] is None:
                 result["storage"] = formatted
+                result["storage_delta"] = delta
+                result["storage_unit"] = unit
 
         return result
 


### PR DESCRIPTION
## Summary
- extend USACE scraper to return 24-hour delta values and units for inflow, outflow, and storage
- show 24-hour change beneath Brookville Lake metrics with color-coded styling

## Testing
- `python -m py_compile dashboard.py scraper.py`
- `python - <<'PY'
from scraper import fetch_usace_brookville_data
print(fetch_usace_brookville_data())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68913986d8d88330b85cc8a4c850c004