### PR TITLE
Fix USGS graph point ordering

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -63,16 +63,23 @@ def _usgs_graph_data_uri(site, days=7):
     if not points:
         return None
 
-    xs, ys = [], []
+    parsed_points = []
     for t_iso, value in points:
         try:
-            xs.append(datetime.fromisoformat(str(t_iso).replace("Z", "+00:00")))
-            ys.append(float(value))
+            timestamp = datetime.fromisoformat(str(t_iso).replace("Z", "+00:00"))
+            parsed_points.append((timestamp, float(value)))
         except (TypeError, ValueError):
             continue
 
-    if not xs:
+    if not parsed_points:
         return None
+
+    # USGS can return the newest observation ahead of the historical values.
+    # Matplotlib connects points in the order provided, so sort by timestamp to
+    # prevent a stray diagonal segment from latest -> oldest across the chart.
+    parsed_points.sort(key=lambda point: point[0])
+    xs = [timestamp for timestamp, _ in parsed_points]
+    ys = [value for _, value in parsed_points]
 
     unit = graph_data.get("unit") or ""
     description = graph_data.get("description") or "Gage height"

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import requests
 
 site_info = [
@@ -60,6 +62,17 @@ def fetch_usgs_timeseries(site_no, parm_cd, period_days=7):
                 points.append((timestamp, float(value)))
             except (TypeError, ValueError):
                 continue
+
+    def timestamp_epoch(point):
+        try:
+            timestamp = datetime.fromisoformat(str(point[0]).replace("Z", "+00:00"))
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            return timestamp.timestamp()
+        except (TypeError, ValueError):
+            return float("inf")
+
+    points.sort(key=timestamp_epoch)
 
     return {
         "points": points,


### PR DESCRIPTION
### Motivation
- USGS timeseries occasionally returns the newest observation out of chronological order, which caused Matplotlib to draw a stray diagonal segment when points were plotted in the received order.
- Ensure graphs are drawn chronologically so the plotted line traces the true time series without jumping from latest back to older points.

### Description
- In `dashboard.py` parse all returned `(timestamp, value)` pairs into `datetime` objects, sort them chronologically, and then build `xs`/`ys` for plotting to prevent out-of-order segments. (changes around `_usgs_graph_data_uri`)
- In `scraper.py` add a `timestamp_epoch` helper that parses timestamps (respecting timezone info) and sort the fetched `points` list before returning it so downstream code receives chronologically ordered data. (added `datetime, timezone` import and sorting)
- A small defensive parsing step was added so invalid timestamps/values are skipped and sorting places unparsable entries at the end.

### Testing
- Ran `python -m py_compile dashboard.py scraper.py` and it completed successfully. 
- Executed a synthetic sorting unit check (simulated `requests.get` response) that validated returned points are chronologically ordered, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b7931a874833085ef76ce565e5139)