### PR TITLE
Format USACE values and tighten graph spacing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -144,9 +144,11 @@ def format_delta(delta, unit):
         text = "24 hour change: N/A"
         color = "gray"
     else:
-        color = "green" if delta > 0 else "red" if delta < 0 else "gray"
-        sign = "+" if delta > 0 else ""
-        text = f"24 hour change: {sign}{delta:.2f} {unit}"
+        numeric_delta = float(delta)
+        color = "green" if numeric_delta > 0 else "red" if numeric_delta < 0 else "gray"
+        sign = "+" if numeric_delta > 0 else "-" if numeric_delta < 0 else ""
+        formatted_delta = f"{abs(numeric_delta):,.2f}".rstrip("0").rstrip(".")
+        text = f"24 hour change: {sign}{formatted_delta} {unit}"
     return f'<span style="font-size:1em;color:{color}">{text}</span>'
 
 # --- PAGE CONFIG ---
@@ -177,17 +179,20 @@ css = """
 
   .stMarkdown, .stMarkdown p { margin: 0 !important; }
   img.graph-img {
-    width: 100%;
-    height: 46vh;
-    max-height: 46vh;
+    width: calc(100% - 12px);
+    height: 44vh;
+    max-height: 44vh;
     object-fit: contain;
     display: block;
+    margin: 6px auto;
     border-radius: 6px;
     background-color: #303030;
   }
   .graph-card {
-    height: 46vh;
-    max-height: 46vh;
+    width: calc(100% - 12px);
+    height: 44vh;
+    max-height: 44vh;
+    margin: 6px auto;
     background-color: #303030;
     border-radius: 6px;
     padding: 16px;
@@ -205,9 +210,11 @@ css = """
 
   /* USACE card (same height as graphs) */
   .usace-card {
+    width: calc(100% - 12px);
+    margin: 6px auto;
     background-color: #303030;
     padding: 12px;
-    height: 46vh;               /* match graph height */
+    height: 44vh;               /* match graph height with spacing */
     display: flex;
     flex-direction: column;
     justify-content: flex-start;

--- a/scraper.py
+++ b/scraper.py
@@ -16,6 +16,15 @@ REQUEST_HEADERS = {
 }
 
 
+def _format_usace_value(value, unit):
+    """Format a USACE numeric value with thousands separators and units."""
+    if value is None:
+        return None
+
+    formatted_value = f"{float(value):,.2f}".rstrip("0").rstrip(".")
+    return f"{formatted_value} {unit}".strip()
+
+
 def _parse_usgs_timestamp(timestamp):
     """Parse a USGS timestamp and normalize naive values to UTC."""
     parsed_timestamp = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
@@ -170,7 +179,7 @@ def fetch_usace_brookville_data():
             value = ts.get("latest_value")
             unit = ts.get("unit", "")
             delta = ts.get("delta24hr")
-            formatted = f"{value:.2f} {unit}" if value is not None else None
+            formatted = _format_usace_value(value, unit)
 
             if label == "elevation":
                 result["elevation"] = formatted


### PR DESCRIPTION
### Motivation
- Make USACE metric numbers human-readable with thousands separators and remove insignificant trailing zeros. 
- Ensure the gray graph/card boxes have spacing so they do not visually touch each other.

### Description
- Add helper ` _format_usace_value(value, unit)` in `scraper.py` to format numeric values with comma separators and trim trailing `.00`, and use it when assembling USACE metrics. 
- Replace the previous raw `f"{value:.2f} {unit}"` formatting with the new helper in `fetch_usace_brookville_data` so stored metric strings are preformatted. 
- Update `format_delta` in `dashboard.py` to coerce the delta to `float`, render an explicit `+`/`-` sign, and format the absolute delta with thousands separators. 
- Reduce graph/card heights and add margins by adjusting CSS in `dashboard.py` (update `img.graph-img`, `.graph-card`, and `.usace-card` to use `calc(100% - 12px)`, smaller `vh` heights, and `margin: 6px auto`).

### Testing
- Ran `python -m py_compile dashboard.py scraper.py` to validate syntax and it succeeded. 
- Executed small assertions calling `_format_usace_value` (e.g. `199999` → `199,999`) and they passed. 
- Ran `git diff --check` to ensure no whitespace errors. 
- Launched the app and verified HTTP response with `curl -I http://127.0.0.1:8501`; the server returned `200 OK`. 
- Attempted automated screenshot with Playwright, but browser download in this environment failed (Playwright CDN returned a 403), so screenshot capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b7f9d4520833081fe8fc5e73d3add)