### PR TITLE
Center latest info inside graph card

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -127,7 +127,12 @@ def render_usgs_graph(site):
         image_uri = graph_uri.get("image_uri")
         latest_text = escape(graph_uri.get("latest_text") or "Latest: N/A")
         st.markdown(
-            f"<img src='{image_uri}' class='graph-img'><div class='latest-info'>{latest_text}</div>",
+            f"""
+            <div class='graph-card graph-data-card'>
+              <img src='{image_uri}' class='graph-img'>
+              <div class='latest-info'>{latest_text}</div>
+            </div>
+            """,
             unsafe_allow_html=True,
         )
     else:
@@ -174,20 +179,21 @@ css = """
 
   .stMarkdown, .stMarkdown p { margin: 0 !important; }
   img.graph-img {
-    width: calc(100% - 12px);
-    height: 44vh;
-    max-height: 44vh;
+    width: 100%;
+    height: calc(44vh - 48px);
+    max-height: calc(44vh - 48px);
     object-fit: contain;
     display: block;
-    margin: 6px auto 2px auto;
+    margin: 0 auto 6px auto;
     border-radius: 6px;
-    background-color: #303030;
   }
   .latest-info {
-    width: calc(100% - 12px);
-    margin: 0 auto 6px auto;
+    width: 100%;
+    margin: 0;
     color: #DDDDDD;
     font-size: 125%;
+    line-height: 1.2;
+    text-align: center;
   }
   .graph-card {
     width: calc(100% - 12px);
@@ -203,6 +209,11 @@ css = """
     flex-direction: column;
     justify-content: center;
     gap: 8px;
+  }
+  .graph-data-card {
+    padding: 6px;
+    justify-content: flex-start;
+    gap: 0;
   }
   .graph-card a { color: #8AB4F8; }
 


### PR DESCRIPTION
### Motivation
- Keep the "Latest:" value visually tied to its graph by placing it inside the same grey card and centering it below the chart so the dashboard reads more clearly and consistently.
- Ensure the fixed-height graph card still fits both the image and the latest-value label by adjusting image sizing and card padding.

### Description
- Updated `render_usgs_graph` to wrap the image and latest-value text in a single HTML block: `<div class='graph-card graph-data-card'>...<img ...><div class='latest-info'>...</div></div>` replacing the previous separate image + label markup.
- Adjusted CSS for `img.graph-img` to use `height: calc(44vh - 48px)` and `width: 100%` so the image leaves room for the label inside the fixed `44vh` card.
- Centered and tightened the label with `.latest-info { text-align: center; line-height: 1.2; margin: 0; }` and added `.graph-data-card` to reduce padding and align content to the top of the card.
- Kept the existing `.graph-card` styling for the grey container so the visuals remain consistent across graph cards.

### Testing
- Ran `python -m py_compile dashboard.py scraper.py` and it succeeded.
- Ran `git diff --check` and it reported no whitespace or diff issues.
- Launched the app and performed a basic health check with `curl -I http://127.0.0.1:8501`, which returned `HTTP/1.1 200 OK`.
- Attempted to capture a screenshot with Playwright via `npx --yes playwright install chromium` / screenshot, but the Playwright browser download failed with `403 Domain forbidden`, so screenshot capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b848cb08c833081eff869690807d0)