### PR TITLE
Show Latest observation time in fixed EDT

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -22,6 +22,7 @@ from scraper import fetch_site_graphs, fetch_usace_brookville_data, fetch_usgs_t
 
 DISPLAY_TIMEZONE = ZoneInfo("America/New_York")
 DISPLAY_TIMEZONE_LABEL = "Eastern Time"
+LATEST_INFO_TIMEZONE = timezone(timedelta(hours=-4), "EDT")
 DISPLAY_TIME_FORMAT = "%m/%d %I:%M %p"
 LAST_UPDATED_TIME_FORMAT = "%Y-%m-%d %I:%M %p"
 
@@ -37,6 +38,14 @@ def _format_display_time(timestamp, time_format=DISPLAY_TIME_FORMAT):
     """Format a timestamp for the dashboard using Eastern Time and 12-hour time."""
     display_timestamp = _to_display_timezone(timestamp)
     return display_timestamp.strftime(f"{time_format} %Z")
+
+
+def _format_latest_info_time(timestamp):
+    """Format the latest-observation timestamp using fixed EDT (UTC-4)."""
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    latest_timestamp = timestamp.astimezone(LATEST_INFO_TIMEZONE)
+    return latest_timestamp.strftime(f"{DISPLAY_TIME_FORMAT} %Z")
 
 
 def _set_eastern_time_axis(ax):
@@ -129,7 +138,7 @@ def _usgs_graph_data(site, days=7):
 
     _set_eastern_time_axis(ax)
 
-    latest_time = _format_display_time(xs[-1])
+    latest_time = _format_latest_info_time(xs[-1])
     latest_value = f"{ys[-1]:.2f} {unit}".strip()
     latest_text = f"Latest: {latest_value} at {latest_time}"
 


### PR DESCRIPTION
### Motivation
- Ensure the dashboard’s "Latest:" observation label is displayed with an explicit EDT timestamp (UTC-4) so the label consistently shows the expected `EDT` suffix regardless of local DST behavior. 

### Description
- Add `LATEST_INFO_TIMEZONE = timezone(timedelta(hours=-4), "EDT")` to define a fixed EDT timezone constant. 
- Introduce `_format_latest_info_time(timestamp)` which converts a timestamp to the fixed `EDT` zone and formats it with `DISPLAY_TIME_FORMAT`. 
- Update the USGS graph card generation to use `_format_latest_info_time(...)` for the `Latest:` label while leaving chart axis ticks and the footer `Last updated:` behavior unchanged. 

### Testing
- Ran `python -m py_compile dashboard.py scraper.py` which succeeded. 
- Executed a targeted formatter check that called `_format_latest_info_time` and verified `datetime(2026,1,1,12:00 UTC)` formats as `01/01 08:00 AM EDT`. 
- Launched the app with `streamlit run dashboard.py` to smoke-test runtime, and an attempted Playwright screenshot failed because Playwright’s browser download was blocked by a `403` from the Playwright CDN.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8b329844833088dcccbbceba0701)