### PR TITLE
Treat negative USACE precipitation sentinel as zero

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -25,6 +25,24 @@ def _format_usace_value(value, unit):
     return f"{formatted_value} {unit}".strip()
 
 
+def _format_usace_precipitation(value, unit):
+    """Format USACE precipitation, treating negative sentinel values as zero.
+
+    The USACE reporting API can return negative placeholder values (for
+    example, ``-901``) when precipitation has not been recorded. Since negative
+    precipitation is not meaningful for the dashboard, display those values as
+    zero instead of surfacing the placeholder to users.
+    """
+    if value is None:
+        return None
+
+    numeric_value = float(value)
+    if numeric_value < 0:
+        numeric_value = 0
+
+    return _format_usace_value(numeric_value, unit)
+
+
 def _parse_usgs_timestamp(timestamp):
     """Parse a USGS timestamp and normalize naive values to UTC."""
     parsed_timestamp = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
@@ -192,7 +210,7 @@ def fetch_usace_brookville_data():
                 result["outflow_delta"] = delta
                 result["outflow_unit"] = unit
             elif label == "precipitation":
-                result["precipitation"] = formatted
+                result["precipitation"] = _format_usace_precipitation(value, unit)
             elif "storage" in label and result["storage"] is None:
                 result["storage"] = formatted
                 result["storage_delta"] = delta

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,15 @@
+import unittest
+
+from scraper import _format_usace_precipitation
+
+
+class FormatUsacePrecipitationTest(unittest.TestCase):
+    def test_negative_precipitation_sentinel_displays_as_zero(self):
+        self.assertEqual(_format_usace_precipitation(-901, "in"), "0 in")
+
+    def test_positive_precipitation_keeps_value_and_unit(self):
+        self.assertEqual(_format_usace_precipitation(1.25, "in"), "1.25 in")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The USACE reporting API can return negative placeholder precipitation values (e.g. `-901`) which are not meaningful and were being displayed directly in the dashboard as `-901 in` instead of `0 in`.

### Description
- Add `_format_usace_precipitation(value, unit)` to coerce negative precipitation sentinel values to zero and then format with ` _format_usace_value`.
- Use `_format_usace_precipitation` when parsing the `precipitation` timeseries in `fetch_usace_brookville_data` so the dashboard shows `0` instead of negative placeholders.
- Add unit tests in `tests/test_scraper.py` covering the negative sentinel and a normal positive precipitation value.

### Testing
- Ran `python -m unittest discover -s tests -v` and both tests passed (`OK`).
- Ran `python -m py_compile scraper.py dashboard.py` which succeeded with no syntax errors.
- Executed `from scraper import fetch_usace_brookville_data; print(fetch_usace_brookville_data()["precipitation"])` which printed `0 in`, confirming the sentinel is converted to zero.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b95b1aabc83309740fad4f1f7fe59)