### PR TITLE
Swap Brookville Lake and East Fork graph positions

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -294,6 +294,22 @@ data.append({
     "image_url": "https://waterdata.usgs.gov/nwisweb/graph?agency_cd=USGS&site_no=03274615&parm_cd=00065&period=7"
 })
 
+# Put the East Fork Whitewater River graph where the Brookville Lake graph
+# previously appeared, and move Brookville Lake into East Fork's former slot.
+brookville_lake_index = next(
+    (index for index, site in enumerate(data) if site.get("site_no") == "03275990"),
+    None,
+)
+east_fork_index = next(
+    (index for index, site in enumerate(data) if site.get("site_no") == "03274615"),
+    None,
+)
+if brookville_lake_index is not None and east_fork_index is not None:
+    data[brookville_lake_index], data[east_fork_index] = (
+        data[east_fork_index],
+        data[brookville_lake_index],
+    )
+
 # --- USACE DATA ---
 # No cache here so it always refetches on rerun
 usace = fetch_usace_brookville_data()


### PR DESCRIPTION
### Motivation
- Reorder the dashboard so the East Fork Whitewater River near Abington graph occupies the slot previously used by the Brookville Lake graph to match the requested display preference.

### Description
- Add logic in `dashboard.py` after the USGS `data` list is built to find entries with `site_no` `03275990` (Brookville Lake) and `03274615` (East Fork) and swap their positions in `data` when both are present.
- Preserve the original site metadata and only change list ordering, leaving graph rendering and USACE data handling unchanged.

### Testing
- Ran `python -m compileall dashboard.py scraper.py tests` which succeeded.
- Ran `pytest -q` in the default environment which failed due to `ModuleNotFoundError` for `scraper` when `PYTHONPATH` was not set, and re-ran `PYTHONPATH=. pytest -q` which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9a11d2208330aed5959b40575998)