### PR TITLE
Update Great Miami River station label

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -288,25 +288,25 @@ def get_usgs_graphs():
 data = get_usgs_graphs()
 data.append({
     "site_no": "03274615",
-    "title": "East Fork Whitewater River near Abington",
+    "title": "Great Miami River at Miamitown OH - USGS-03274615",
     "parm_cd": "00065",
     "page_url": "https://waterdata.usgs.gov/monitoring-location/USGS-03274615",
     "image_url": "https://waterdata.usgs.gov/nwisweb/graph?agency_cd=USGS&site_no=03274615&parm_cd=00065&period=7"
 })
 
-# Put the East Fork Whitewater River graph where the Brookville Lake graph
-# previously appeared, and move Brookville Lake into East Fork's former slot.
+# Put the Great Miami River graph where the Brookville Lake graph
+# previously appeared, and move Brookville Lake into Great Miami's former slot.
 brookville_lake_index = next(
     (index for index, site in enumerate(data) if site.get("site_no") == "03275990"),
     None,
 )
-east_fork_index = next(
+great_miami_index = next(
     (index for index, site in enumerate(data) if site.get("site_no") == "03274615"),
     None,
 )
-if brookville_lake_index is not None and east_fork_index is not None:
-    data[brookville_lake_index], data[east_fork_index] = (
-        data[east_fork_index],
+if brookville_lake_index is not None and great_miami_index is not None:
+    data[brookville_lake_index], data[great_miami_index] = (
+        data[great_miami_index],
         data[brookville_lake_index],
     )
 


### PR DESCRIPTION
### Motivation
- Correct the displayed station label for site `03274615` and update nearby placement logic to reference the actual Great Miami River station.

### Description
- In `dashboard.py` replaced the title for site `03274615` with `Great Miami River at Miamitown OH - USGS-03274615`, updated the placement comment, and renamed the index variable from `east_fork_index` to `great_miami_index` while preserving the swap logic.

### Testing
- Ran `python -m py_compile dashboard.py scraper.py`, which completed successfully.
- Ran `git diff --check`, which reported no issues.
- Attempted `npx playwright install chromium` to capture a Streamlit screenshot, but the browser download was blocked by the environment (HTTP 403) so screenshot capture failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9f1d61548330a93977442d2fc1d5)