### PR TITLE
Show USACE water temperature and relabel precipitation to 24hr total

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -548,7 +548,7 @@ with cols_bottom[2]:
           {storage_delta_html}
 
           <div style="font-size:125%; margin-top:8px;">
-            Precipitation= {usace.get('precipitation') or 'N/A'}
+            Precipitation 24hr total= {usace.get('precipitation') or 'N/A'} &nbsp;&nbsp; Water Temp= {usace.get('water_temp') or 'N/A'}
           </div>
 
           {f"<img src='{graph_uri}' style='width:100%; height:22vh; object-fit:contain; margin-top:8px; background:#303030; border-radius:4px;'/>" if graph_uri else ""}

--- a/scraper.py
+++ b/scraper.py
@@ -43,6 +43,20 @@ def _format_usace_precipitation(value, unit):
     return _format_usace_value(numeric_value, unit)
 
 
+def _format_usace_temperature_f(value, unit):
+    """Format a USACE water temperature value in Fahrenheit."""
+    if value is None:
+        return None
+
+    numeric_value = float(value)
+    normalized_unit = (unit or "").strip().lower()
+    if normalized_unit in {"c", "celsius", "deg c", "degrees celsius", "°c"}:
+        numeric_value = (numeric_value * 9 / 5) + 32
+
+    formatted_value = f"{numeric_value:,.1f}".rstrip("0").rstrip(".")
+    return f"{formatted_value} °F"
+
+
 def _parse_usgs_timestamp(timestamp):
     """Parse a USGS timestamp and normalize naive values to UTC."""
     parsed_timestamp = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
@@ -190,6 +204,7 @@ def fetch_usace_brookville_data():
             "storage_delta": None,
             "storage_unit": None,
             "precipitation": None,
+            "water_temp": None,
             "inflow_tsid": None,
             "outflow_tsid": None,
         }
@@ -215,6 +230,8 @@ def fetch_usace_brookville_data():
                 result["outflow_tsid"] = ts.get("tsid")
             elif label == "precipitation":
                 result["precipitation"] = _format_usace_precipitation(value, unit)
+            elif "water" in label and "temp" in label:
+                result["water_temp"] = _format_usace_temperature_f(value, unit)
             elif "storage" in label and result["storage"] is None:
                 result["storage"] = formatted
                 result["storage_delta"] = delta

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,7 +1,11 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from scraper import _format_usace_precipitation, fetch_usace_brookville_data
+from scraper import (
+    _format_usace_precipitation,
+    _format_usace_temperature_f,
+    fetch_usace_brookville_data,
+)
 
 
 class FormatUsacePrecipitationTest(unittest.TestCase):
@@ -10,6 +14,14 @@ class FormatUsacePrecipitationTest(unittest.TestCase):
 
     def test_positive_precipitation_keeps_value_and_unit(self):
         self.assertEqual(_format_usace_precipitation(1.25, "in"), "1.25 in")
+
+
+class FormatUsaceTemperatureTest(unittest.TestCase):
+    def test_fahrenheit_temperature_uses_degree_symbol(self):
+        self.assertEqual(_format_usace_temperature_f(68, "F"), "68 °F")
+
+    def test_celsius_temperature_converts_to_fahrenheit(self):
+        self.assertEqual(_format_usace_temperature_f(20, "C"), "68 °F")
 
 
 class FetchUsaceBrookvilleDataTest(unittest.TestCase):
@@ -33,6 +45,11 @@ class FetchUsaceBrookvilleDataTest(unittest.TestCase):
                         "delta24hr": -2,
                         "tsid": "Brookville.Flow-Outflow.Ave.1Hour.1Hour.lrldlb-comp",
                     },
+                    {
+                        "label": "Water Temp",
+                        "latest_value": 20,
+                        "unit": "C",
+                    },
                 ]
             }
         ]
@@ -49,6 +66,7 @@ class FetchUsaceBrookvilleDataTest(unittest.TestCase):
             data["outflow_tsid"],
             "Brookville.Flow-Outflow.Ave.1Hour.1Hour.lrldlb-comp",
         )
+        self.assertEqual(data["water_temp"], "68 °F")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Relabel the USACE precipitation metric to clarify it is a 24-hour total and display the reservoir water temperature on the same line in Fahrenheit with a degree symbol.

### Description
- Update `dashboard.py` to replace `Precipitation=` with `Precipitation 24hr total=` and append `Water Temp=` on the same display line using `usace.get('water_temp')`.
- Add `_format_usace_temperature_f` to `scraper.py` to format temperatures in Fahrenheit and convert from Celsius when the unit indicates Celsius, appending `°F`.
- Extend the `fetch_usace_brookville_data` result to include a `water_temp` key and detect timeseries labels that contain both `water` and `temp` to populate it.
- Add unit tests in `tests/test_scraper.py` to verify Fahrenheit formatting, Celsius-to-Fahrenheit conversion, and extraction of the mocked water temperature timeseries value.

### Testing
- Ran `python -m unittest discover -s tests`, which executed 5 tests and returned `OK`.
- Ran `git diff --check` to ensure there are no whitespace or diff issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba7920c10833091f65b21e407291a)