### PR TITLE
Reduce dashboard card height to avoid scrollbar

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -218,8 +218,8 @@ css = """
   .stMarkdown, .stMarkdown p { margin: 0 !important; }
   img.graph-img {
     width: 100%;
-    height: calc((100vh - 58px) / 2 - 24px);
-    max-height: calc((100vh - 58px) / 2 - 24px);
+    height: calc((100vh - 82px) / 2 - 24px);
+    max-height: calc((100vh - 82px) / 2 - 24px);
     object-fit: contain;
     display: block;
     margin: 0 auto 2px auto;
@@ -235,8 +235,8 @@ css = """
   }
   .graph-card {
     width: calc(100% - 4px);
-    height: calc((100vh - 58px) / 2);
-    max-height: calc((100vh - 58px) / 2);
+    height: calc((100vh - 82px) / 2);
+    max-height: calc((100vh - 82px) / 2);
     margin: 2px auto;
     background-color: #303030;
     border-radius: 6px;
@@ -264,7 +264,7 @@ css = """
     margin: 2px auto;
     background-color: #303030;
     padding: 8px;
-    height: calc((100vh - 58px) / 2); /* match graph height with spacing on 1920x1080 */
+    height: calc((100vh - 82px) / 2); /* match graph height while avoiding page scrollbar */
     display: flex;
     flex-direction: column;
     justify-content: flex-start;


### PR DESCRIPTION
### Motivation

- The two-row dashboard layout produced a browser vertical scrollbar at common viewport heights, so the visible graph/card heights were reduced to prevent scrolling.
- The USACE card should remain visually aligned with the graph cards after the change.

### Description

- Adjusted CSS in `dashboard.py` to reduce the per-row viewport allocation by increasing the subtracted offset from `58px` to `82px` for height calculations. 
- Updated `img.graph-img` `height`/`max-height` `calc(...)` expressions to use `calc((100vh - 82px) / 2 - 24px)`.
- Updated `.graph-card` and `.usace-card` `height`/`max-height` `calc(...)` expressions to use `calc((100vh - 82px) / 2)` and updated the comment to reflect the intent.

### Testing

- `python -m py_compile dashboard.py` completed successfully. 
- `PYTHONPATH=. pytest -q` ran the test suite and all tests passed (`5 passed`).
- Running `pytest -q` without `PYTHONPATH=.` failed during collection with `ModuleNotFoundError: No module named 'scraper'`, indicating the test runner requires the repo root on `PYTHONPATH` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1babb140dc8330b35ab742f0563ab5)