### PR TITLE
Move 'Last updated' caption above graphs

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -492,6 +492,10 @@ def get_usace_inflow_outflow_graph(inflow_tsid, outflow_tsid):
     return _usace_io_graph_data_uri(inflow_tsid, outflow_tsid, days=7)
 
 
+# --- LAST UPDATED HEADER ---
+updated_time = _format_display_time(datetime.now(timezone.utc), LAST_UPDATED_TIME_FORMAT)
+st.caption(f"Last updated: {updated_time}")
+
 # --- LAYOUT ---
 # Row 1: 3 graphs
 cols_top = st.columns(3)
@@ -570,7 +574,3 @@ with cols_bottom[2]:
             """,
             unsafe_allow_html=True,
         )
-
-# --- LAST UPDATED FOOTER ---
-updated_time = _format_display_time(datetime.now(timezone.utc), LAST_UPDATED_TIME_FORMAT)
-st.caption(f"Last updated: {updated_time}")


### PR DESCRIPTION
### Motivation
- Ensure the dashboard's "Last updated:" timestamp is visible immediately, above the graph grid, so users see data recency before viewing graphs.

### Description
- Inserted a header block that computes `updated_time` with `_format_display_time` and renders `st.caption("Last updated: {updated_time}")` immediately before the graph layout.
- Removed the previous footer placement of the same caption so the timestamp no longer appears below the dashboard cards.
- All changes are contained in `dashboard.py` (moved the timestamp rendering above the `# --- LAYOUT ---` marker and removed the footer block).

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and returned success.
- Ran `python -m py_compile dashboard.py` which succeeded with no syntax errors.
- Launched the app and ran `curl -I --max-time 10 http://127.0.0.1:8501` which returned HTTP 200 OK.
- Attempted `python -m playwright install chromium` to capture a UI screenshot, but the browser download failed with an HTTP 403 (`Domain forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1baeba6d508330ac963d51e7a4bb74)