### PR TITLE
Tighten dashboard height for 1080p

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -195,6 +195,12 @@ st.set_page_config(page_title="USGS Water Graphs", layout="wide")
 # --- STYLE ---
 css = """
 <style>
+  :root {
+    --dashboard-card-height: calc((100vh - 140px) / 2);
+    --dashboard-image-height: calc(var(--dashboard-card-height) - 27px);
+    --dashboard-card-spacing: 1px;
+  }
+
   .block-container {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
@@ -209,6 +215,8 @@ css = """
   }
   div[data-testid="stStatusWidget"] { display: none !important; }
   div[data-testid="stDecoration"] { display: none !important; }
+  div[data-testid="stVerticalBlock"] { gap: 4px !important; }
+  div[data-testid="stElementContainer"] { margin: 0 !important; }
 
   /* Columns: remove default top spacing and align content to top */
   [data-testid="column"] {
@@ -221,11 +229,11 @@ css = """
   .stMarkdown, .stMarkdown p { margin: 0 !important; }
   img.graph-img {
     width: 100%;
-    height: calc((100vh - 64px) / 2 - 20px);
-    max-height: calc((100vh - 64px) / 2 - 20px);
+    height: var(--dashboard-image-height);
+    max-height: var(--dashboard-image-height);
     object-fit: contain;
     display: block;
-    margin: 0 auto 1px auto;
+    margin: 0 auto var(--dashboard-card-spacing) auto;
     border-radius: 6px;
   }
   .latest-info {
@@ -238,9 +246,9 @@ css = """
   }
   .graph-card {
     width: calc(100% - 4px);
-    height: calc((100vh - 64px) / 2);
-    max-height: calc((100vh - 64px) / 2);
-    margin: 0 auto 2px auto;
+    height: var(--dashboard-card-height);
+    max-height: var(--dashboard-card-height);
+    margin: 0 auto var(--dashboard-card-spacing) auto;
     background-color: #303030;
     border-radius: 6px;
     padding: 6px;
@@ -258,16 +266,20 @@ css = """
   }
   .graph-card a { color: #8AB4F8; }
 
+  html, body, [data-testid="stAppViewContainer"], .stApp {
+    overflow: hidden !important;
+  }
+
   /* App background */
   .stApp { background-color: #171717; }
 
   /* USACE card (same height as graphs) */
   .usace-card {
     width: calc(100% - 4px);
-    margin: 0 auto 2px auto;
+    margin: 0 auto var(--dashboard-card-spacing) auto;
     background-color: #303030;
     padding: 6px;
-    height: calc((100vh - 64px) / 2); /* match graph height while avoiding page scrollbar */
+    height: var(--dashboard-card-height); /* match graph height while avoiding page scrollbar */
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
@@ -560,7 +572,7 @@ with cols_bottom[2]:
             Precipitation 24hr total= {usace.get('precipitation') or 'N/A'}
           </div>
 
-          {f"<img src='{graph_uri}' style='width:100%; height:22vh; object-fit:contain; margin-top:8px; background:#303030; border-radius:4px;'/>" if graph_uri else ""}
+          {f"<img src='{graph_uri}' style='width:100%; height:17vh; object-fit:contain; margin-top:8px; background:#303030; border-radius:4px;'/>" if graph_uri else ""}
         </div>
         """
         st.markdown(usace_html, unsafe_allow_html=True)


### PR DESCRIPTION
### Motivation
- Ensure the two-row dashboard fits a 1920×1080 viewport without a vertical scrollbar. 
- Reduce Streamlit vertical gaps and card margins so USACE and USGS panels share a compact, consistent height.

### Description
- Add CSS root variables `--dashboard-card-height`, `--dashboard-image-height`, and `--dashboard-card-spacing` and apply them to card and image sizing. 
- Replace previous `calc((100vh - 64px) / 2)` heights with `var(--dashboard-card-height)` and use `var(--dashboard-image-height)` for graph images. 
- Tighten Streamlit spacing by forcing `div[data-testid="stVerticalBlock"] { gap: 4px }` and `div[data-testid="stElementContainer"] { margin: 0 }`, and set `overflow: hidden` on `html, body, [data-testid="stAppViewContainer"], .stApp` to avoid scrollbars. 
- Reduce the embedded USACE inflow/outflow chart height from `22vh` to `17vh` to keep the bottom card within the compact row height.

### Testing
- `python -m py_compile dashboard.py scraper.py` — passed. 
- `python -m unittest discover -s tests` — all tests ran (`5` tests) and passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bb9925cb88330ab5319b2ee46bb80)