### PR TITLE
Lower "Last updated" footer (increase footer height & adjust alignment)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -197,7 +197,7 @@ css = """
 <style>
   :root {
     --dashboard-row-gap: 18px;
-    --dashboard-footer-height: 26px;
+    --dashboard-footer-height: 42px;
     --dashboard-card-padding: 4px;
     --dashboard-latest-height: 28px;
     --dashboard-card-height: calc((100vh - 84px - var(--dashboard-row-gap) - var(--dashboard-footer-height)) / 2);
@@ -288,12 +288,12 @@ css = """
   .last-updated-footer {
     height: var(--dashboard-footer-height);
     display: flex;
-    align-items: flex-end;
+    align-items: flex-start;
     justify-content: center;
     color: #BDBDBD;
     font-size: 0.85rem;
     line-height: 1;
-    padding-bottom: 2px;
+    padding-top: 14px;
     box-sizing: border-box;
     background: transparent;
   }


### PR DESCRIPTION
### Motivation

- Provide more vertical space below the graph rows so the `Last updated` timestamp does not overlap or sit too close to the graphs.

### Description

- Increased CSS variable `--dashboard-footer-height` from `26px` to `42px` to reserve more footer space in the layout.
- Adjusted `.last-updated-footer` alignment by changing `align-items: flex-end` to `align-items: flex-start` and replaced `padding-bottom: 2px` with `padding-top: 14px` so the timestamp sits lower within the newly reserved footer area.

### Testing

- Ran `python -m py_compile dashboard.py`, which completed successfully.
- Attempted `python -m playwright install chromium` for browser-based verification, which failed due to a download `403 Domain forbidden` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c52146ce88330a8c6c347484aa895)