### PR TITLE
Add footer spacing below graph cards

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -198,9 +198,12 @@ css = """
   :root {
     --dashboard-row-gap: 18px;
     --dashboard-footer-height: 42px;
+    --dashboard-footer-top-gap: 14px;
     --dashboard-card-padding: 4px;
     --dashboard-latest-height: 28px;
-    --dashboard-card-height: calc((100vh - 84px - var(--dashboard-row-gap) - var(--dashboard-footer-height)) / 2);
+    --dashboard-card-height: calc(
+      (100vh - 84px - var(--dashboard-row-gap) - var(--dashboard-footer-height) - var(--dashboard-footer-top-gap)) / 2
+    );
     --dashboard-image-height: calc(
       var(--dashboard-card-height) - var(--dashboard-latest-height) - (2 * var(--dashboard-card-padding))
     );
@@ -287,6 +290,7 @@ css = """
   }
   .last-updated-footer {
     height: var(--dashboard-footer-height);
+    margin-top: var(--dashboard-footer-top-gap);
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
### Motivation
- The dashboard layout placed the last-updated footer too close to the graph cards, making the light-gray graph area feel visually cramped. 
- The intent is to reserve explicit vertical space for the footer without introducing page overflow when calculating card heights.

### Description
- Add a new CSS variable `--dashboard-footer-top-gap` to the `:root` to represent the reserved gap above the footer. 
- Subtract the new `--dashboard-footer-top-gap` from the `--dashboard-card-height` calculation so graph cards account for the extra footer spacing. 
- Apply `margin-top: var(--dashboard-footer-top-gap)` to the `.last-updated-footer` rule to move the footer away from the cards. 
- Reformat the card-height calc to a multiline expression for readability.

### Testing
- Ran `python -m pytest -q` and all tests passed (`5 passed`).
- Ran `git diff --check` and the repository checks reported no issues. 
- Attempted visual verification via Playwright, but browser installation failed when downloading Chromium from the Playwright CDN (HTTP 403), so screenshot checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c56e0b0148330a9384ef196ef27a6)